### PR TITLE
Introduce EcdsaSecp256k1Signature2019 and EcdsaSecp256k1VerificationKey2019

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@ the community.
       <tbody>
         <tr>
           <td>Identifiers</td>
-          <td>EdDsaSASignatureSecp256k1, EdDsaSAPublicKeySecp256k1</td>
+          <td>ECDSASecp256k1Signature2018, Secp256k1VerificationKey2018</td>
         </tr>
         <tr>
           <td>Status</td>
@@ -276,9 +276,9 @@ the community.
       </tbody>
     </table>
 
-    <pre class="example nohighlight" title="Example of Ed25519VerificationKey2018">{
+    <pre class="example nohighlight" title="Example of Secp256k1VerificationKey2018">{
   "id": "did:example:123456789abcdefghi#keys-1",
-  "type": "EdDsaSAPublicKeySecp256k1",
+  "type": "Secp256k1VerificationKey2018",
   "owner": "did:example:123456789abcdefghi",
   "publicKeyHex": "02b97c30de767f084...263d29f1450936b71"
 }</pre>

--- a/index.html
+++ b/index.html
@@ -247,6 +247,37 @@ the community.
   </section>
 
   <section>
+    <h2>EcdsaKoblitzSignature2016</h2>
+
+    <table class="simple">
+      <thead>
+        <tr>
+          <th colspan=2>Summary</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>Identifiers</td>
+          <td>EcdsaKoblitzSignature2016</td>
+        </tr>
+        <tr>
+          <td>Status</td>
+          <td>PROVISIONAL</td>
+        </tr>
+        <tr>
+          <td>Authors</td>
+          <td>Harlan Wood, Manu Sporny</td>
+        </tr>
+        <tr>
+          <td>Specification</td>
+          <td><a href="https://w3c-dvcg.github.io/lds-koblitz2016/">Koblitz Signature Suite 2016</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
     <h2>EcdsaSecp256k1Signature2019</h2>
 
     <table class="simple">
@@ -271,7 +302,7 @@ the community.
         </tr>
         <tr>
           <td>Specification</td>
-          <td>(needs spec) <a href="https://w3c-dvcg.github.io/lds-secp256k1-2019/">Secp256k1 Signature Suite 2019</a></td>
+          <td>(needs specification) <a href="https://w3c-dvcg.github.io/lds-ecdsa-secp256k1-2019/">ECDSA Secp256k1 Signature Suite 2019</a></td>
         </tr>
       </tbody>
     </table>

--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@ the community.
   </section>
 
   <section>
-    <h2>EdDsaSASignatureSecp256k1</h2>
+    <h2>EcdsaSecp256k1Signature2019</h2>
 
     <table class="simple">
       <thead>
@@ -259,7 +259,7 @@ the community.
       <tbody>
         <tr>
           <td>Identifiers</td>
-          <td>ECDSASecp256k1Signature2018, Secp256k1VerificationKey2018</td>
+          <td>EcdsaSecp256k1Signature2019, Secp256k1VerificationKey2018</td>
         </tr>
         <tr>
           <td>Status</td>

--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@ the community.
       <tbody>
         <tr>
           <td>Identifiers</td>
-          <td>EcdsaSecp256k1Signature2019, Secp256k1VerificationKey2018</td>
+          <td>EcdsaSecp256k1Signature2019, EcdsaSecp256k1VerificationKey2019</td>
         </tr>
         <tr>
           <td>Status</td>
@@ -267,18 +267,18 @@ the community.
         </tr>
         <tr>
           <td>Authors</td>
-          <td>Harlan Wood, Manu Sporny</td>
+          <td>(needs authors)</td>
         </tr>
         <tr>
           <td>Specification</td>
-          <td>(needs new spec?) <a href="https://w3c-dvcg.github.io/lds-koblitz2016/">Koblitz Signature Suite 2016</a></td>
+          <td>(needs spec) <a href="https://w3c-dvcg.github.io/lds-secp256k1-2019/">Secp256k1 Signature Suite 2019</a></td>
         </tr>
       </tbody>
     </table>
 
-    <pre class="example nohighlight" title="Example of Secp256k1VerificationKey2018">{
+    <pre class="example nohighlight" title="Example of EcdsaSecp256k1VerificationKey2019">{
   "id": "did:example:123456789abcdefghi#keys-1",
-  "type": "Secp256k1VerificationKey2018",
+  "type": "EcdsaSecp256k1VerificationKey2019",
   "owner": "did:example:123456789abcdefghi",
   "publicKeyHex": "02b97c30de767f084...263d29f1450936b71"
 }</pre>

--- a/index.html
+++ b/index.html
@@ -271,7 +271,7 @@ the community.
         </tr>
         <tr>
           <td>Specification</td>
-          <td><a href="https://w3c-dvcg.github.io/lds-koblitz2016/">Koblitz Signature Suite 2016</a></td>
+          <td>(needs new spec?) <a href="https://w3c-dvcg.github.io/lds-koblitz2016/">Koblitz Signature Suite 2016</a></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
Fixes https://github.com/w3c-ccg/ld-cryptosuite-registry/issues/8. Fixes https://github.com/w3c-ccg/ld-cryptosuite-registry/issues/9. 
Replaces https://github.com/w3c-ccg/ld-cryptosuite-registry/pull/4. Replaces https://github.com/w3c-ccg/ld-cryptosuite-registry/pull/7.

@mikelodder7 @dlongley @kimdhamilton @ChristopherA 