### PR TITLE
Create sections for Verification Methods and Signature Suites

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,15 +162,15 @@ and request assistance via the
 </section>
 
 <section>
-<h1>The Registry</h1>
+<h1>Verification Methods</h1>
 
 <p>
-This section summarizes the Linked Data key specifications currently known to
+This section summarizes the verification methods currently known to
 the community.
 </p>
 
   <section>
-    <h2>Ed25519Signature2018</h2>
+    <h2>Ed25519VerificationKey2018</h2>
 
     <table class="simple">
       <thead>
@@ -182,7 +182,7 @@ the community.
       <tbody>
         <tr>
           <td>Identifiers</td>
-          <td>Ed25519Signature2018, Ed25519VerificationKey2018</td>
+          <td>Ed25519VerificationKey2018</td>
         </tr>
         <tr>
           <td>Status</td>
@@ -194,7 +194,7 @@ the community.
         </tr>
         <tr>
           <td>Specification</td>
-          <td><a href="https://w3c-dvcg.github.io/lds-ed25519-2018/">Ed25519 Signature Suite 2018</a></td>
+          <td><a href="https://w3c-dvcg.github.io/lds-ed25519-2018/#the-ed25519-key-format">Ed25519 Signature 2018: key format</a></td>
         </tr>
       </tbody>
     </table>
@@ -209,7 +209,7 @@ the community.
   </section>
 
   <section>
-    <h2>RsaSignature2018</h2>
+    <h2>RsaVerificationKey2018</h2>
 
     <table class="simple">
       <thead>
@@ -221,7 +221,7 @@ the community.
       <tbody>
         <tr>
           <td>Identifiers</td>
-          <td>RsaSignature2018, RsaVerificationKey2018</td>
+          <td>RsaVerificationKey2018</td>
         </tr>
         <tr>
           <td>Status</td>
@@ -244,6 +244,118 @@ the community.
   "owner": "did:example:123456789abcdefghi",
   "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
 }</pre>
+  </section>
+
+  <section>
+    <h2>EcdsaSecp256k1VerificationKey2019</h2>
+
+    <table class="simple">
+      <thead>
+        <tr>
+          <th colspan=2>Summary</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>Identifiers</td>
+          <td>EcdsaSecp256k1VerificationKey2019</td>
+        </tr>
+        <tr>
+          <td>Status</td>
+          <td>PROVISIONAL</td>
+        </tr>
+        <tr>
+          <td>Authors</td>
+          <td>(needs authors)</td>
+        </tr>
+        <tr>
+          <td>Specification</td>
+          <td>(needs specification) <a href="https://w3c-dvcg.github.io/lds-ecdsa-secp256k1-2019/">ECDSA Secp256k1 Signature Suite 2019</a></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <pre class="example nohighlight" title="Example of EcdsaSecp256k1VerificationKey2019">{
+  "id": "did:example:123456789abcdefghi#keys-1",
+  "type": "EcdsaSecp256k1VerificationKey2019",
+  "owner": "did:example:123456789abcdefghi",
+  "publicKeyHex": "02b97c30de767f084...263d29f1450936b71"
+}</pre>
+  </section>
+
+</section>
+
+<section>
+<h1>Signature Suites</h1>
+
+<p>
+This section summarizes the signature suites currently known to
+the community.
+</p>
+
+  <section>
+    <h2>Ed25519Signature2018</h2>
+
+    <table class="simple">
+      <thead>
+        <tr>
+          <th colspan=2>Summary</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>Identifiers</td>
+          <td>Ed25519Signature2018</td>
+        </tr>
+        <tr>
+          <td>Status</td>
+          <td>PROVISIONAL</td>
+        </tr>
+        <tr>
+          <td>Authors</td>
+          <td>Markus Sabadello</td>
+        </tr>
+        <tr>
+          <td>Specification</td>
+          <td><a href="https://w3c-dvcg.github.io/lds-ed25519-2018/">Ed25519 Signature Suite 2018</a></td>
+        </tr>
+      </tbody>
+    </table>
+
+  </section>
+
+  <section>
+    <h2>RsaSignature2018</h2>
+
+    <table class="simple">
+      <thead>
+        <tr>
+          <th colspan=2>Summary</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>Identifiers</td>
+          <td>RsaSignature2018</td>
+        </tr>
+        <tr>
+          <td>Status</td>
+          <td>PROVISIONAL</td>
+        </tr>
+        <tr>
+          <td>Authors</td>
+          <td>Dave Longley, Manu Sporny</td>
+        </tr>
+        <tr>
+          <td>Specification</td>
+          <td><a href="https://w3c-dvcg.github.io/lds-rsa2018/">RSA Signature Suite 2018</a></td>
+        </tr>
+      </tbody>
+    </table>
+
   </section>
 
   <section>
@@ -290,7 +402,7 @@ the community.
       <tbody>
         <tr>
           <td>Identifiers</td>
-          <td>EcdsaSecp256k1Signature2019, EcdsaSecp256k1VerificationKey2019</td>
+          <td>EcdsaSecp256k1Signature2019</td>
         </tr>
         <tr>
           <td>Status</td>
@@ -307,12 +419,6 @@ the community.
       </tbody>
     </table>
 
-    <pre class="example nohighlight" title="Example of EcdsaSecp256k1VerificationKey2019">{
-  "id": "did:example:123456789abcdefghi#keys-1",
-  "type": "EcdsaSecp256k1VerificationKey2019",
-  "owner": "did:example:123456789abcdefghi",
-  "publicKeyHex": "02b97c30de767f084...263d29f1450936b71"
-}</pre>
   </section>
 
 </section>


### PR DESCRIPTION
Re: https://github.com/w3c-ccg/community/issues/56

I don't fully understand this stuff but I've done the best with the information I have. The two sections are Verification Methods (containing key formats) and Signatures Suites (containing signature suites).

Todo/help wanted:
* I haven't added any editorial blurb because I don't know what it should say.
* Ed25519VerificationKey2018 links to the key formats section of the Ed25519 Signatures spec, is that okay?
* RsaVerificationKey2018 and EcdsaSecp256k1VerificationKey2019 link to the equivalent SignatureSuite specs because that's what was there before, but neither of which mention anything about key formats. Do they need to link to somewhere else? Do those specs just need updating?

I think then the next thing that needs doing is adding all the other keys listed in https://w3c-ccg.github.io/did-spec/#public-keys to the Verification Methods section? (As a separate PR)