### PR TITLE
Change "owner" to "controller" in examples.

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@ the community.
   "@context": ["https://w3id.org/security/v1"],
   "id": "did:example:123456789abcdefghi#keys-1",
   "type": "Ed25519VerificationKey2018",
-  "owner": "did:example:123456789abcdefghi",
+  "controller": "did:example:123456789abcdefghi",
   "publicKeyBase58" : "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
 }</pre>
   </section>
@@ -241,7 +241,7 @@ the community.
     <pre class="example nohighlight" title="Example of RsaVerificationKey2018">{
   "id": "did:example:123456789abcdefghi#keys-1",
   "type": "RsaVerificationKey2018",
-  "owner": "did:example:123456789abcdefghi",
+  "controller": "did:example:123456789abcdefghi",
   "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
 }</pre>
   </section>
@@ -279,7 +279,7 @@ the community.
     <pre class="example nohighlight" title="Example of EcdsaSecp256k1VerificationKey2019">{
   "id": "did:example:123456789abcdefghi#keys-1",
   "type": "EcdsaSecp256k1VerificationKey2019",
-  "owner": "did:example:123456789abcdefghi",
+  "controller": "did:example:123456789abcdefghi",
   "publicKeyHex": "02b97c30de767f084...263d29f1450936b71"
 }</pre>
   </section>


### PR DESCRIPTION
To make public key examples consistent with their respective specs.