### PR TITLE
feat: add bbs bls signature and key definitions to registry

### DIFF
--- a/index.html
+++ b/index.html
@@ -747,6 +747,148 @@ Suites that support multiple verification methods MUST state so explicitly, and 
   </section>
 
 </section>
+
+<section>
+  <h2>BBS+ Signature 2020</h2>
+  
+  <section>
+
+  <h3>BbsBlsSignature2020</h3>
+
+  <table class="simple">
+    <thead>
+      <tr>
+        <th colspan=2>Summary</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <td>Identifiers</td>
+        <td>BbsBlsSignature2020</td>
+      </tr>
+      <tr>
+        <td>Status</td>
+        <td>PROVISIONAL</td>
+      </tr>
+      <tr>
+        <td>Authors</td>
+        <td>Tobias Looker, Orie Steele</td>
+      </tr>
+      <tr>
+        <td>Specification</td>
+        <td><a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Signatures 2020</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>BbsBlsSignatureProof2020</h3>
+
+  <table class="simple">
+    <thead>
+      <tr>
+        <th colspan=2>Summary</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <td>Identifiers</td>
+        <td>BbsBlsSignatureProof2020</td>
+      </tr>
+      <tr>
+        <td>Status</td>
+        <td>PROVISIONAL</td>
+      </tr>
+      <tr>
+        <td>Authors</td>
+        <td>Tobias Looker, Orie Steele</td>
+      </tr>
+      <tr>
+        <td>Specification</td>
+        <td><a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Signatures 2020</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Bls12381G1Key2020</h3>
+
+  <table class="simple">
+    <thead>
+      <tr>
+        <th colspan=2>Summary</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <td>Identifiers</td>
+        <td>Bls12381G1Key2020</td>
+      </tr>
+      <tr>
+        <td>Status</td>
+        <td>PROVISIONAL</td>
+      </tr>
+      <tr>
+        <td>Authors</td>
+       <td>Tobias Looker, Orie Steele</td>
+      </tr>
+      <tr>
+        <td>Specification</td>
+        <td><a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Signatures 2020</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <pre class="example nohighlight" title="Example of Bls12381G1Key2020">
+    {
+      "id": "did:example:489398593#test",
+      "type": "Bls12381G1Key2020",
+      "controller": "did:example:489398593",
+      "publicKeyBase58": "4N9Kg9BxmDXtf2QgRH2j1UfFAcQAmgu9Xpwe2fLbSNQHPQHBK5dHrQfFvexvux"
+    }
+  </pre>
+
+  <h3>Bls12381G2Key2020</h3>
+
+  <table class="simple">
+    <thead>
+      <tr>
+        <th colspan=2>Summary</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <td>Identifiers</td>
+        <td>Bls12381G2Key2020</td>
+      </tr>
+      <tr>
+        <td>Status</td>
+        <td>PROVISIONAL</td>
+      </tr>
+      <tr>
+        <td>Authors</td>
+       <td>Tobias Looker, Orie Steele</td>
+      </tr>
+      <tr>
+        <td>Specification</td>
+        <td><a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Signatures 2020</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <pre class="example nohighlight" title="Example of Bls12381G2Key2020">
+    {
+      "id": "did:example:489398593#test",
+      "type": "Bls12381G2Key2020",
+      "controller": "did:example:489398593",
+      "publicKeyBase58": "oqpWYKaZD9M1Kbe94BVXpr8WTdFBNZyKv48cziTiQUeuhm7sBhCABMyYG4kcMrseC68YTFFgyhiNeBKjzdKk9MiRWuLv5H4FFujQsQK2KTAtzU8qTBiZqBHMmnLF4PL7Ytu"
+    }
+  </pre>
+</section>
+
+</section>
 </section>
 
 </body>


### PR DESCRIPTION
Adds the BBS and BLS signature and key definitions to the registry defined in https://w3c-ccg.github.io/ldp-bbs2020/

PR is dependent on https://github.com/w3c-ccg/ldp-bbs2020/pull/34 being merged ahead for the Bls12381G1Key2020 definition 